### PR TITLE
feat: add rate limiting when fetching urls

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -2,5 +2,9 @@ package constants
 
 import "time"
 
-const HttpTimeout = 10 * time.Second
-const MaxConcurrentRequests = 20
+const HttpTimeout = 20 * time.Second
+const MaxConcurrentRequests = 15
+const RequestsPerSecond = 2.0
+const MaxRetries = 3
+const InitalBackoff = time.Second
+const BackoffFactor = 2.0

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -2,12 +2,14 @@ package utils
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func CleanText(raw string) string {
@@ -88,4 +90,21 @@ func GrepString(baseString, searchString string) bool {
 
 func AddToBaseUrl(addString string) string {
 	return fmt.Sprintf("https://www.examtopics.com%s", addString)
+}
+
+func CreateRateLimiter(rps float64) *time.Ticker {
+	interval := time.Duration(float64(time.Second) / rps)
+	return time.NewTicker(interval)
+}
+
+func DelayTime(backoff time.Duration) time.Duration {
+	return backoff + time.Duration(rand.Intn(500))*time.Millisecond
+}
+
+func BackoffTime(backoff time.Duration, backoffFactor float64) time.Duration {
+	return time.Duration(float64(backoff) * backoffFactor)
+}
+
+func Sleep(seconds time.Duration) {
+	time.Sleep(seconds)
 }


### PR DESCRIPTION
This PR closes #2 and improves rate limiting when getting the files from the examtopics website. There will also be further improvement to the speed in coming updates when adding the `cache`.

# Summary
- Add more constants in `constants.go` to handle rate limiting
- Fix up `fetch.go` and `scraper.go` for external fetching
- Add more functions to `utils.go` to help with handling the time calculations and rate limiting

