### PR TITLE
feat: add caching to main go files, by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,18 @@ Each command line argument you can provide when running the program:
   -c	Optionally include all the comment/discussion text
   -exams
     	Optionally show all the possible exams for your selected provider and exit
+  -no-cache
+    	Optional argument, set to disable looking through cached data on github
   -o string
     	Optional path of the file where the data will be outputted (default "examtopics_output.md")
   -p string
-    	Name of the exam provider (default "google")
+    	Name of the exam provider (default -> google) (default "google")
   -s string
     	String to grep for in discussion links (required)
   -save-links
     	Optional argument to save unique links to questions
+  -t string
+    	Optional argument to make cached requests faster to gh api
 ```
 
 ## Possible Arguments List
@@ -122,6 +126,16 @@ The `-c` argument is another bool flag, so it is defaultly set to false(as it cr
 ### Exams output, `-exams`
 
 This argument will display output defaulted to such as and exit immediately.
+
+### Token Input, `-t`
+
+When you add you `Github` PAT, it allows for more requests to the API, (up to 5000) which is needed when scraping bigger things.
+The cached data helps you access big dumps faster.
+
+### No Cache Arg, `-no-cache`
+
+When you add this argument, it tells the program to ignore the cached `Github` repoitories of updated exam info, however the scraper will take longer than the cache.
+Useful when wanting to scrape realtime data.
 
 ```
 Exams for provider 'google'
@@ -174,7 +188,7 @@ Successfully saved output to {OUTPUT_LOCATION}.
 ```
 
 If so, hooray, you have successfully saved all/most of the questions in a `.md` file!
-The format would be such as:
+The format would be such as (older, only scraping format):
 
 ```
 ----------------------------------------

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,8 @@ func main() {
 	commentBool := flag.Bool("c", false, "Optionally include all the comment/discussion text")
 	examsFlag := flag.Bool("exams", false, "Optionally show all the possible exams for your selected provider and exit")
 	saveUrls := flag.Bool("save-links", false, "Optional argument to save unique links to questions")
+	noCache := flag.Bool("no-cache", false, "Optional argument, set to disable looking through cached data on github")
+	token := flag.String("t", "", "Optional argument to make cached requests faster to gh api")
 	flag.Parse()
 
 	if *examsFlag {
@@ -32,13 +34,21 @@ func main() {
 		log.Println("running without a valid string to search for with -s, (no_grep_str)!")
 	}
 
+	if !*noCache {
+		links := fetch.GetCachedPages(*provider, *grepStr, *token)
+		if links != nil {
+			utils.WriteData(links, *outputPath, *commentBool)
+			fmt.Printf("Successfully saved cached output to %s.\n", *outputPath)
+			os.Exit(0)
+		}
+	}
+
+	fmt.Println("Going to manual scraping, cached data failed.")
 	links := fetch.GetAllPages(*provider, *grepStr)
 
 	if *saveUrls {
 		utils.SaveLinks("saved-links.txt", links)
 	}
-
 	utils.WriteData(links, *outputPath, *commentBool)
-
 	fmt.Printf("Successfully saved output to %s.\n", *outputPath)
 }

--- a/internal/models/question.go
+++ b/internal/models/question.go
@@ -10,3 +10,35 @@ type QuestionData struct {
 	QuestionLink string
 	Comments     string
 }
+
+type FileInfo struct {
+	URL    string
+	Name   string
+	Number int
+}
+
+type JSONResponse struct {
+	PageProps struct {
+		Questions []struct {
+			Choices           map[string]string `json:"choices"`
+			ID                string            `json:"id"`
+			ExamID            int               `json:"exam_id"`
+			QuestionText      string            `json:"question_text"`
+			Answer            string            `json:"answer"`
+			AnswerET          string            `json:"answer_ET"`
+			Topic             string            `json:"topic"`
+			IsMC              bool              `json:"isMC"`
+			AnswerDescription string            `json:"answer_description"`
+			Discussion        []struct {
+				Content     string `json:"content"`
+				UpvoteCount string `json:"upvote_count"`
+				Poster      string `json:"poster"`
+				Timestamp   string `json:"timestamp"`
+			} `json:"discussion"`
+			AnswerImages   []string `json:"answer_images"`
+			QuestionImages []string `json:"question_images"`
+			URL            string   `json:"url"`
+			Timestamp      string   `json:"timestamp"`
+		} `json:"questions"`
+	} `json:"pageProps"`
+}

--- a/internal/models/transport.go
+++ b/internal/models/transport.go
@@ -1,0 +1,13 @@
+package models
+
+import "net/http"
+
+type AuthTransport struct {
+	Token     string
+	Transport http.RoundTripper
+}
+
+func (a *AuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Authorization", "Bearer "+a.Token)
+	return a.Transport.RoundTrip(req)
+}

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -36,7 +36,10 @@ func WriteData(dataList []models.QuestionData, outputPath string, commentBool bo
 
 		fmt.Fprintf(file, "## %s\n\n", data.Title)
 		fmt.Fprintf(file, "%s\n\n", data.Header)
-		fmt.Fprintf(file, "%s\n\n", data.Content)
+
+		if data.Content != "" {
+			fmt.Fprintf(file, "%s\n\n", data.Content)
+		}
 
 		for _, question := range data.Questions {
 			fmt.Fprintf(file, "%s\n\n", question)
@@ -50,7 +53,7 @@ func WriteData(dataList []models.QuestionData, outputPath string, commentBool bo
 			fmt.Fprintf(file, "Comments: %s\n", data.Comments)
 		}
 
-		fmt.Fprintf(file, "----------------------------------------\n")
+		fmt.Fprintf(file, "----------------------------------------\n\n")
 	}
 }
 


### PR DESCRIPTION
Useful addition to add caching by default, speeds up by over 200%. 
(still needs refactoring though)

# Summary
- Adds caching to files using outside repo which contains updated examtopics data
- Improves speed and stability of program if crashing/lagging
- Adds more models for easier data collection and code readability
- Adds more util functions used in tandem with fetch.go, etc.
- Add new command line args for adding token, `-t` and `-no-cache` for more user control