### PR TITLE
fix: update GitHub API URL and enhance grep string normalization for cached links multiple dashes

### DIFF
--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -155,7 +155,7 @@ func FetchCachedLinks(providerName string, grepStr string, token string) []strin
 	for _, item := range content {
 		link := item.URL
 		number := utils.ExtractNumberFromPath(item.Name)
-		if utils.GrepString(link, grepStr) {
+		if utils.GrepStringFromCache(link, grepStr) {
 			linksWithNumbers = append(linksWithNumbers, models.FileInfo{
 				URL:    link,
 				Name:   item.Name,

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -60,7 +60,7 @@ func WriteData(dataList []models.QuestionData, outputPath string, commentBool bo
 func SaveLinks(filename string, links []models.QuestionData) {
 	var fullLinks []string
 	for _, link := range links {
-		fullLinks = append(fullLinks, AddToBaseUrl(link.QuestionLink))
+		fullLinks = append(fullLinks, link.QuestionLink)
 	}
 	writeFile(filename, fullLinks)
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -104,10 +104,34 @@ func SortLinksByQuestionNumber(links []string) []string {
 	return links
 }
 
+func normalize(s string) string {
+	s = strings.ToLower(s)
+
+	// Replace multiple dashes with a single dash
+	reDash := regexp.MustCompile(`-+`)
+	s = reDash.ReplaceAllString(s, "-")
+
+	// Remove suffix like _xxx.json (if any)
+	reSuffix := regexp.MustCompile(`(_\d+)?\.json$`)
+	s = reSuffix.ReplaceAllString(s, "")
+
+	return s
+}
+
 func GrepString(baseString, searchString string) bool {
 	return strings.Contains(
 		strings.ToLower(baseString),
 		strings.ToLower(searchString),
+	)
+}
+
+func GrepStringFromCache(baseString, searchString string) bool {
+	baseNorm := normalize(baseString)
+	searchNorm := normalize(searchString)
+
+	return strings.Contains(
+		baseNorm,
+		searchNorm,
 	)
 }
 


### PR DESCRIPTION
## Problem

1. For certain exams in `examtopics-data`:

   - **String to grep:** `aws-certified-machine-learning-engineer-associate-mla-c01`  
   - **JSON file:** `AWS-Certified-Machine-Learning-Engineer---Associate-MLA-C01_1.json`  

   These do not match.

   **Cause:** JSON file contains multiple dashes. The `utils.GrepString` function is currently used the same way for both fetching from cache and fetching fresh data from ExamTopics, but the input formats differ.

2. When fetching fresh data from ExamTopics, saving unique links results in duplicate domains.

   - `QuestionData.QuestionLink` already contains the ExamTopics domain, yet `AddToBaseUrl(link.QuestionLink)` is still applied.

---

## Solution

1. **Separate `utils.GrepString` behavior** between fetching from cache and fetching fresh data.

   - When fetching from cache, before grepping:
     - Replace multiple dashes with a single dash.
     - Remove suffix like `_xxx.json` (if any).

2. **When fetching fresh data**, avoid adding the domain twice:
   - Do not use `AddToBaseUrl(link.QuestionLink)` since the domain already exists in `QuestionData.QuestionLink`.
