### PR TITLE
feat: add JSON output format (closes #14) and fix empty answers on live scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,13 @@ Currently we have these types supported:
 - `html` -> generates `examtopics_output.html`
 - `pdf` -> generates `examtopics_output.pdf`
 - `txt` -> generates `examtopics_output.txt`
+- `json` -> generates `examtopics_output.json`
 
 > [!NOTE]  
 > Files are kept in same/similar format as you would see in the `.md` file, for formatting changes, use other arguments.
+
+> [!NOTE]  
+> The `json` type emits structured data (one object per question, with `title`, `header`, `content`, `questions`, `answer`, `timestamp`, `question_link` and `comments`), suitable for programmatic use such as flash-card generators, study apps or further scripting.
 
 ## [For outputted file examples, see the examples folder](examples/google_devops.md)
 

--- a/internal/fetch/scraper.go
+++ b/internal/fetch/scraper.go
@@ -29,10 +29,37 @@ func getDataFromLink(link string) *models.QuestionData {
 		allQuestions = append(allQuestions, utils.CleanText(s.Text()))
 	})
 
-	answerText := strings.TrimSpace(doc.Find(".correct-answer").Text())
+	// ExamTopics now embeds the community-voted answer in a hidden JSON
+	// <script> inside .voted-answers-tally instead of the old .correct-answer.
 	answer := ""
-	if len(answerText) > 0 {
-		answer = string(strings.ReplaceAll(strings.ReplaceAll(answerText, " ", ""), "\n", "")[0])
+	jsonText := strings.TrimSpace(doc.Find(".voted-answers-tally script").First().Text())
+	if jsonText != "" {
+		var votes []struct {
+			VotedAnswers string `json:"voted_answers"`
+			VoteCount    int    `json:"vote_count"`
+			IsMostVoted  bool   `json:"is_most_voted"`
+		}
+		if err := json.Unmarshal([]byte(jsonText), &votes); err != nil {
+			log.Printf("failed to parse voted-answers JSON for %s: %v", link, err)
+		} else {
+			for _, v := range votes {
+				if v.IsMostVoted {
+					answer = v.VotedAnswers
+					break
+				}
+			}
+			if answer == "" && len(votes) > 0 {
+				answer = votes[0].VotedAnswers
+			}
+		}
+	}
+
+	// Fallback to the legacy selector if the JSON tally is absent.
+	if answer == "" {
+		answerText := strings.TrimSpace(doc.Find(".correct-answer").Text())
+		if len(answerText) > 0 {
+			answer = string(strings.ReplaceAll(strings.ReplaceAll(answerText, " ", ""), "\n", "")[0])
+		}
 	}
 
 	return &models.QuestionData{

--- a/internal/models/question.go
+++ b/internal/models/question.go
@@ -1,14 +1,14 @@
 package models
 
 type QuestionData struct {
-	Title        string
-	Header       string
-	Content      string
-	Questions    []string
-	Answer       string
-	Timestamp    string
-	QuestionLink string
-	Comments     string
+	Title        string   `json:"title"`
+	Header       string   `json:"header"`
+	Content      string   `json:"content"`
+	Questions    []string `json:"questions"`
+	Answer       string   `json:"answer"`
+	Timestamp    string   `json:"timestamp"`
+	QuestionLink string   `json:"question_link"`
+	Comments     string   `json:"comments"`
 }
 
 type FileInfo struct {

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"regexp"
 	"examtopics-downloader/internal/models"
 	"fmt"
@@ -66,6 +67,19 @@ func WriteData(dataList []models.QuestionData, outputPath string, commentBool bo
 	}
 
 	switch fileType {
+	case "json":
+		jsonBytes, err := json.MarshalIndent(dataList, "", "  ")
+		if err != nil {
+			log.Printf("json marshal failed: %v", err)
+			return
+		}
+
+		fileName := strings.TrimSuffix(outputPath, ".md") + ".json"
+		if err := os.WriteFile(fileName, jsonBytes, 0644); err != nil {
+			log.Printf("failed to write json file: %v", err)
+			return
+		}
+		deleteMarkdownFile(outputPath)
 	case "pdf":
 		mdContent, err := os.ReadFile(outputPath)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Add a `json` option to `-type` that serializes the scraped questions to a structured `.json` file (handled in `internal/utils/files.go`)
- Add JSON tags to the `QuestionData` model so the output uses clean `snake_case` keys
- Fix empty `Answer` field when scraping live (`-no-cache`): ExamTopics moved the suggested answer into a hidden JSON `<script>`, so the old selector no longer matched
- Document the new `json` type in `README.md`

## Why
### JSON output (closes #14)
Issue #14 requested structured output for downstream tooling (flash-card generators, study apps, custom scripts). The scraper already builds a clean `QuestionData` struct, so this just serializes it. Each object contains `title`, `header`, `content`, `questions`, `answer`, `timestamp`, `question_link` and `comments`.

Usage:
```bash
go run ./cmd/main.go -p google -s professional-cloud-developer -c -type json -o output.md
# -> output.json
```

### Answer extraction fix
When the GitHub cache is unavailable and the tool falls back to live scraping, the `Answer` field came out empty. ExamTopics now embeds the community-voted answer in a hidden `<script type="application/json">` inside `.voted-answers-tally` instead of the old `.correct-answer` element:
```html
<div class="voted-answers-tally d-none">
  <script type="application/json">[{"voted_answers": "A", "vote_count": 7, "is_most_voted": true}]</script>
</div>
```
`getDataFromLink` now parses that JSON and picks the entry flagged `is_most_voted`, falling back to the first entry and then to the legacy `.correct-answer` selector for backwards compatibility.

## Testing
- `go build ./...` passes
- Verified the new selector against the raw HTML (no JS) of a live discussion page — the `voted-answers-tally` JSON is present in the server response, so `goquery` can read it